### PR TITLE
feat: Setup ignore host key for jumphost

### DIFF
--- a/src/commands/setup-ignore-host-key.yml
+++ b/src/commands/setup-ignore-host-key.yml
@@ -1,0 +1,18 @@
+description: >
+  Disable StrictHostKeyChecking and set UserKnownHostsFile to /dev/null for a given host pattern.
+  This allows you to connect to ssh keys you configured in CircleCI without a host specified
+
+parameters:
+  host-pattern:
+    type: string
+    description: Host pattern to configure the host key ignore for
+
+steps:
+  - run:
+      name: Setup ignore host key for pattern <<parameters.host-pattern>>
+      command: |
+        cat \<<EOT >> ~/.ssh/config
+        Host <<parameters.host-pattern>>
+          StrictHostKeyChecking no
+          UserKnownHostsFile=/dev/null
+        EOT

--- a/src/examples/job-run-with-jumphost-ansible.yml
+++ b/src/examples/job-run-with-jumphost-ansible.yml
@@ -1,7 +1,7 @@
 description: >
   Using the jumphost job with minimal configuration to do your deployment.
   This example assumes you specify the jumphost configuration inside ansible or in any other
-  provisionnig tool you use.
+  provisioning tool you use.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/job-run-with-ssh-jumphost-config.yml
+++ b/src/examples/job-run-with-ssh-jumphost-config.yml
@@ -1,7 +1,5 @@
 description: >
   Using the jumphost job with minimal configuration to do your deployment.
-  This example assumes you specify the jumphost configuration inside ansible or in any other
-  provisionnig tool you use.
 usage:
   version: 2.1
   orbs:

--- a/src/jobs/run-with-jumphost.yml
+++ b/src/jobs/run-with-jumphost.yml
@@ -1,5 +1,6 @@
 description: >
-  Run given steps with a open jumphost connection
+  Run given steps with a open jumphost connection.
+  This also ensures the host key for your jumphost is ignored to prevent interactive dialogs inside the pipeline.
 
 executor: <<parameters.executor>>
 
@@ -37,6 +38,8 @@ parameters:
     description: Steps to execute with connection open
 
 steps:
+  - setup-ignore-host-key:
+      host-pattern: <<parameters.jumphost-hostname>>
   - run-with-jumphost:
       jumphost-hostname: <<parameters.jumphost-hostname>>
       key-fingerprint: <<parameters.key-fingerprint>>


### PR DESCRIPTION
## Description
This ensures that ssh connections the jumphost do not ask for hostkey approval even if the pattern does not match with the jumphost configuration.

CircleCI does not do this by default, so we need to manually do it in a separate step.